### PR TITLE
update rtd badge url

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ Introduction
 ============
 
 
-.. image:: https://readthedocs.org/projects/adafruit-circuitpython-pixelmap/badge/?version=latest
+.. image:: https://readthedocs.org/projects/circuitpython-pixelmap/badge/?version=latest
     :target: https://docs.circuitpython.org/projects/pixelmap/en/latest/
     :alt: Documentation Status
 


### PR DESCRIPTION
the slug for this project is `circuitpython-pixelmap` https://app.readthedocs.org/projects/circuitpython-pixelmap/builds/

This being mismatched also causes issues for adabot, first noticed here: https://github.com/adafruit/adabot/pull/394